### PR TITLE
fix: LGTM, LGTNをUpcaseした

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -26,17 +26,17 @@
     </div>
     <div>
       <div class="form-check form-check-inline">
-        <input class="form-check-input" type="radio" name="chooseOverlay" id="inlineRadio1" value="lgtm" checked />
+        <input class="form-check-input" type="radio" name="chooseOverlay" id="inlineRadio1" value="LGTM" checked />
         <label class="form-check-label" for="inlineRadio1">LGTM画像を生成</label>
       </div>
       <div class="form-check form-check-inline">
-        <input class="form-check-input" type="radio" name="chooseOverlay" id="inlineRadio2" value="lgtn" />
+        <input class="form-check-input" type="radio" name="chooseOverlay" id="inlineRadio2" value="LGTN" />
         <label class="form-check-label" for="inlineRadio2">LGTN画像を生成</label>
       </div>
     </div>
     <img id="pasted-image" hidden />
-    <img id="img__lgtm" src="./img/lgtm.png" hidden />
-    <img id="img__lgtn" src="./img/lgtn.png" hidden />
+    <img id="img__LGTM" src="./img/lgtm.png" hidden />
+    <img id="img__LGTN" src="./img/lgtn.png" hidden />
     <canvas id="output-image" width="400" height="400"></canvas>
     <div class="alert alert-warning" role="alert">
       <h2>使用方法</h2>


### PR DESCRIPTION
画像名、img要素のID、メッセージ表示を全て大文字に合わせるため