### PR TITLE
Redraw時のフラグ管理変更

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -27,7 +27,7 @@
 
   <body>
     <main class="container">
-      <h1>LGTN Generator <small>v0.6.0</small></h1>
+      <h1>LGTN Generator <small>v0.6.1</small></h1>
       <div class="row">
         <div class="col-md-6">
           <div id="paste-area">


### PR DESCRIPTION
- 画像生成時にhistoryに元画像を追加するかどうかのフラグをグローバルに持たせる
- 画像生成する関数ではこのフラグを参照してHistoryに追加するかどうかを判断し、必ずfalseに戻す

画像生成のタイミングをsrc要素のonloadイベントハンドラで行っているため、イベント発生のたびに履歴に追加するかどうかを外部注入できないので妥協した